### PR TITLE
Add support for sharedflow in cleanOldRevisions

### DIFF
--- a/cleanOldRevisions.js
+++ b/cleanOldRevisions.js
@@ -108,6 +108,8 @@ apigee.connect(common.optToOptions(opt))
           // convert for GAAMBO
           if (results.proxies && results.proxies.length) {
             results = results.proxies.map(r => r.name);
+          } else if (results.sharedFlows && results.sharedFlows.length) {
+            results = results.sharedFlows.map(r => r.name);
           }
         }
         if (opt.options.regexp) {


### PR DESCRIPTION
Trying to use the cleanOldRevisions in ApigeeX I got an error because it misses a flow that already exists for proxies.
This PR will just the extra flow for the structure sharedFlows (if exists)